### PR TITLE
This fixes the PoS rewind issues.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2044,7 +2044,7 @@ bool CBlock::AddToBlockIndex(unsigned int nFile, unsigned int nBlockPos)
         return false;
 
     // New best
-    if (pindexNew->bnChainTrust > bnBestChainTrust)
+    if (pindexNew->bnChainTrust > bnBestChainTrust && pindexNew->nHeight > nBestHeight)
         if (!SetBestChain(txdb, pindexNew))
             return false;
 

--- a/src/version.h
+++ b/src/version.h
@@ -25,7 +25,7 @@ extern const std::string CLIENT_DATE;
 // network protocol versioning
 //
 
-static const int PROTOCOL_VERSION = 60007;
+static const int PROTOCOL_VERSION = 60008;
 
 // earlier versions not supported as of July 14, 2014, and are disconnected
 static const int MIN_PROTO_VERSION = 209;


### PR DESCRIPTION
SetBestChain is broken (see: https://bitcointalk.org/index.php?topic=331394.msg28128479#msg28128479 and later comments for full details). TL;DR: paccoin is subject to rewind attacks, double spend, and lost work -- this needs to be fixed ASAP.